### PR TITLE
Just use ExtUtils::MakeMaker

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -8,7 +8,6 @@ copyright_year   = 2016
 -bundle = @Basic
 -remove = License
 [AutoPrereqs]
-[ModuleBuild]
 [PodSyntaxTests]
 [PodCoverageTests]
 [MetaResources]


### PR DESCRIPTION
Module::Build is no longer in core, and it is not a great idea to use both Module::Build and ExtUtils::MakeMaker (e.g. see http://neilb.org/2015/05/18/two-build-files-considered-harmful.html). Since Dist::Zilla is in use here, it is very easy to just use EUMM.
