### PR TITLE
Added [MetaJSON] to dist.ini, so releases include a META.json

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,8 @@
 Revision history for Perl extension File-Remove
 
+1.58    2018-10-?? - Shlomi Fish
+    - Added [MetaJSON] to dist.ini, so releases include a META.json
+
 1.57    2016-04-24 - Shlomi Fish
     - Correct the copyright holder and year.
     - Add a test for Kwalitee and 'use warnings'.

--- a/dist.ini
+++ b/dist.ini
@@ -8,6 +8,7 @@ copyright_year   = 1998
 -bundle = @Basic
 -remove = License
 [AutoPrereqs]
+[MetaJSON]
 [MetaResources]
 bugtracker.web = http://rt.cpan.org/NoAuth/Bugs.html?Dist=File-Remove
 bugtracker.mailto = bug-file-remove@rt.cpan.org

--- a/lib/File/Remove.pm
+++ b/lib/File/Remove.pm
@@ -7,7 +7,7 @@ use warnings;
 use vars qw{ @ISA @EXPORT_OK };
 use vars qw{ $DEBUG $unlink $rmdir    };
 
-our $VERSION = '1.57';
+our $VERSION = '1.58';
 
 BEGIN {
 	# $VERSION   = eval $VERSION;


### PR DESCRIPTION
Hi Shlomi,

This just adds `[MetaJSON]` to `dist.ini`, so that releases will include a `META.json` file (because that gives better fidelity of dependency information than the YAML file).

Cheers,
Neil
